### PR TITLE
Upgrade docker to support bionic stemcells

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,10 @@ docker/bridge-utils-1.5.tar.gz:
   size: 33472
   object_id: 239d81d0-bb81-46bc-56a7-34a9d8125dc6
   sha: 1f71b6f22f5d2b6d21e146f4ac20820ad42e58ee
-docker/docker-1.13.1.tgz:
-  size: 27851024
-  object_id: 10f12f08-f5f2-4ad2-4069-44a53678b944
-  sha: 0ff46d8eea0c694f349e1d40cdc10200a1a19e2c
+docker/docker-20.10.8.tgz:
+  size: 60948356
+  object_id: ada23d00-4dd9-4dad-6e30-c99b74247629
+  sha: sha256:7ea11ecb100fdc085dbfd9ab1ff380e7f99733c890ed815510a5952e5d6dd7e0
 docker/swarm-1.1.0.tar:
   size: 18152448
   object_id: 758f1628-847a-4697-756a-94126486315c

--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -33,9 +33,6 @@ properties:
     description: "TCP port where Docker daemon will listen to (if not set, TCP will not be available)"
     default: "4243"
 
-  api_cors_header:
-    description: "Set CORS headers in the remote API"
-    default: false
   bridge:
     description: "Name of the network bridge to attach containers (defaults to docker0)"
   cidr_prefix:
@@ -53,8 +50,6 @@ properties:
     description: "Array of DNS servers to be used by Docker"
   dns_domains:
     description: "Array of DNS search domains to be used by Docker"
-  exec_driver:
-    description: "Use a specific exec driver"
   exec_options:
     description: "Array of exec driver options"
   icc:

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -58,8 +58,7 @@ case $1 in
         set -e
     fi
 
-    exec chpst -u ${DOCKER_USER}:${DOCKER_GROUP} docker daemon \
-        ${DOCKER_API_CORS_HEADER:-} \
+    exec chpst -u ${DOCKER_USER}:${DOCKER_GROUP} dockerd \
         ${DOCKER_BRIDGE:-} \
         ${DOCKER_DEBUG:-} \
         ${DOCKER_DEFAULT_GATEWAY:-} \
@@ -67,7 +66,6 @@ case $1 in
         ${DOCKER_DEFAULT_ULIMITS:-} \
         ${DOCKER_DNS_DOMAINS:-} \
         ${DOCKER_DNS_SERVERS:-} \
-        ${DOCKER_EXEC_DRIVER:-} \
         ${DOCKER_EXEC_OPTIONS:-} \
         --group ${DOCKER_GROUP} \
         --graph ${DOCKER_STORE_DIR}/docker \
@@ -87,7 +85,7 @@ case $1 in
         ${DOCKER_STORAGE_OPTIONS:-} \
         ${DOCKER_SELINUX_ENABLED:-} \
         ${DOCKER_TCP:-} \
-        ${DOCKER_TLS:-} \
+        ${DOCKER_TLS_VERIFY_ENABLED:-} \
         ${DOCKER_TLS_CACERT:-} \
         ${DOCKER_TLS_CERT:-} \
         ${DOCKER_TLS_KEY:-} \

--- a/jobs/docker/templates/bin/props.sh
+++ b/jobs/docker/templates/bin/props.sh
@@ -26,9 +26,6 @@ export DOCKER_GROUP="<%= p('group') %>"
 export DOCKER_TCP="--host tcp://<%= address %>:<%= port %>"
 <% end %>
 
-# Set CORS headers in the remote API
-export DOCKER_API_CORS_HEADER="--api-enable-cors=<%= p('api_cors_header') %>"
-
 <% if_p('bridge', 'cidr_prefix') do |bridge, cidr_prefix| %>
 # Attach containers to a network bridge
 export DOCKER_BRIDGE="--bridge=<%= bridge %>"
@@ -65,11 +62,6 @@ export DOCKER_DNS_DOMAINS="<%= dns_domains_list %>"
 <% dns_servers_list = dns_servers.map { |dns_server| "--dns=#{dns_server}" }.join(' ') %>
 # Array of DNS servers to be used by Docker
 export DOCKER_DNS_SERVERS="<%= dns_servers_list %>"
-<% end %>
-
-<% if_p('exec_driver') do |exec_driver| %>
-# Use a specific exec driver
-export DOCKER_EXEC_DRIVER"--exec-driver=<%= exec_driver %>"
 <% end %>
 
 <% if_p('exec_options') do |exec_options| %>
@@ -134,7 +126,7 @@ export DOCKER_STORAGE_OPTIONS="<%= storage_options_list %>"
 <% end %>
 
 # Always use TLS
-export DOCKER_TLS="--tlsverify"
+export DOCKER_TLS_VERIFY_ENABLED="--tlsverify"
 export DOCKER_TLS_CACERT="--tlscacert=${DOCKER_CONF_DIR}/ca"
 export DOCKER_TLS_CERT="--tlscert=${DOCKER_CONF_DIR}/cert"
 export DOCKER_TLS_KEY="--tlskey=${DOCKER_CONF_DIR}/private_key"

--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -4,7 +4,7 @@ set -e -u
 
 CPUS=`grep -c ^processor /proc/cpuinfo`
 
-tar xzvf docker/docker-1.13.1.tgz
+tar xzvf docker/docker-20.10.8.tgz
 
 # We grab the latest versions that are in the directory
 AUFS_TOOLS_VERSION=`ls -r docker/aufs-tools_*.deb | sed 's/docker\/aufs-tools_\(.*\).deb/\1/' | head -1`

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -5,5 +5,5 @@ files:
 - docker/aufs-tools_20120411-3_amd64.deb
 - docker/autoconf-2.69.tar.gz
 - docker/bridge-utils-1.5.tar.gz
-- docker/docker-1.13.1.tgz
+- docker/docker-20.10.8.tgz
 - ctl_utils.sh


### PR DESCRIPTION
Current docker daemon fail to start containers under bionic stemcells with the error `no subsystem for mount`

After merging, you'll need to upload the `docker/docker-20.10.8.tgz` bosh blob, source can be found here: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.8.tgz

Changes:
- Upgrade docker from 1.13.1 to 20.10.8
- Remove options the docker cli no longer supports
- Change from "docker daemon" to "dockerd" as "docker daemon" is no longer a command
- Rename TLS environment variables as the old names interfere with the docker cli
  when trying to run the stop script